### PR TITLE
Ignore unsaved files

### DIFF
--- a/Plugin/Plugin.cs
+++ b/Plugin/Plugin.cs
@@ -69,13 +69,16 @@ namespace EditorConfig.VisualStudio
             ClearMessage();
             settings = null;
 
+            // Prevent parsing of internet-located documents,
+            // or documents that do not have proper paths.
+            if (path.StartsWith("http:", StringComparison.OrdinalIgnoreCase)
+                || path.Equals("Temp.txt"))
+                return;
+
             try
             {
-                if (!path.StartsWith("http:", StringComparison.OrdinalIgnoreCase))
-                {
-                    settings = Core.Parse(path);
-                    ApplyLocalSettings();
-                }
+                settings = Core.Parse(path);
+                ApplyLocalSettings();
             }
             catch (ParseException e)
             {


### PR DESCRIPTION
Fixed an error when using unsaved files in SSDT (e.g. Schema Compare, connected SQL sessions).
Just checks for the default file path ("Temp.txt") and ignores those files.
