### PR TITLE
Refactor; Restore global settings on LostFocus

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,10 @@ end_of_line = LF
 indent_style = space
 indent_size = 4
 
+[*.csproj]
+indent_style = space
+indent_size = 2
+
 [*.cpp]
 indent_style = space
 indent_size = 2

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@ Martijn Laarman
 Hong Xu
 Tom Potts
 Ethan J. Brown
+Jed Hunsaker

--- a/EditorConfig.VisualStudio.sln.DotSettings
+++ b/EditorConfig.VisualStudio.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AA_BB" /&gt;</s:String></wpf:ResourceDictionary>

--- a/Plugin/Helpers/ResultsExtensions.cs
+++ b/Plugin/Helpers/ResultsExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Globalization;
+
+namespace EditorConfig.VisualStudio.Helpers
+{
+    internal static class ResultsExtensions
+    {
+        internal static void IfHasKeyTrySetting(this Results results, string key, Action<int> setter)
+        {
+            if (!results.ContainsKey(key)) return;
+            int value;
+            if (int.TryParse(results[key], NumberStyles.Integer, null, out value))
+                setter(value);
+        }
+    }
+}

--- a/Plugin/Plugin.cs
+++ b/Plugin/Plugin.cs
@@ -1,230 +1,59 @@
-using System;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using System;
 
 namespace EditorConfig.VisualStudio
 {
+    using Settings;
+
     /// <summary>
     /// This plugin attaches to an editor instance and updates its settings at
     /// the appropriate times
     /// </summary>
-    internal class Plugin
+    internal class Plugin : IDisposable
     {
-        IWpfTextView view;
-        DTE dte;
-        ErrorListProvider messageList;
-        ErrorTask message;
-        Results settings;
+        private readonly IWpfTextView _view;
+        private readonly ITextDocument _doc;
+        private readonly Results _settings;
+        private readonly Loader _loader;
+        private readonly GlobalSettings _globalSettings;
 
-        public Plugin(IWpfTextView view, ITextDocument document, DTE dte, ErrorListProvider messageList)
+        public Plugin(IWpfTextView view, ITextDocument document, DTE app, ErrorListProvider messageList)
         {
-            this.view = view;
-            this.dte = dte;
-            this.messageList = messageList;
-            this.message = null;
+            _view = view;
+            _doc = document;
+            _loader = new Loader(view, document, messageList);
+            _globalSettings = new GlobalSettings(view, app, _settings = _loader.Settings);
 
             document.FileActionOccurred += FileActionOccurred;
-            view.GotAggregateFocus += GotAggregateFocus;
             view.Closed += Closed;
-
-            LoadSettings(document.FilePath);
         }
 
         /// <summary>
         /// Reloads the settings when the filename changes
         /// </summary>
-        void FileActionOccurred(object sender, TextDocumentFileActionEventArgs e)
+        private void FileActionOccurred(object sender, TextDocumentFileActionEventArgs e)
         {
             if ((e.FileActionType & FileActionTypes.DocumentRenamed) != 0)
-                LoadSettings(e.FilePath);
+                _loader.LoadSettings(e.FilePath);
 
-            if (settings != null && view.HasAggregateFocus)
-                ApplyGlobalSettings();
+            if (_settings != null && _view.HasAggregateFocus)
+                _globalSettings.Apply();
         }
 
-        /// <summary>
-        /// Updates the global settings when the local editor receives focus
-        /// </summary>
-        void GotAggregateFocus(object sender, EventArgs e)
+        private void Closed(object sender, EventArgs e)
         {
-            if (settings != null)
-                ApplyGlobalSettings();
+            Dispose();
         }
 
-        /// <summary>
-        /// Removes the any messages when the document is closed
-        /// </summary>
-        void Closed(object sender, EventArgs e)
+        public void Dispose()
         {
-            ClearMessage();
-        }
-
-        /// <summary>
-        /// Loads the settings for the given file path
-        /// </summary>
-        private void LoadSettings(string path)
-        {
-            ClearMessage();
-            settings = null;
-
-            // Prevent parsing of internet-located documents,
-            // or documents that do not have proper paths.
-            if (path.StartsWith("http:", StringComparison.OrdinalIgnoreCase)
-                || path.Equals("Temp.txt"))
-                return;
-
-            try
-            {
-                settings = Core.Parse(path);
-                ApplyLocalSettings();
-            }
-            catch (ParseException e)
-            {
-                ShowError(path, "EditorConfig syntax error in file \"" + e.File + "\", line " + e.Line);
-            }
-            catch (CoreException e)
-            {
-                ShowError(path, "EditorConfig core error: " + e.Message);
-            }
-        }
-
-        /// <summary>
-        /// Applies settings to the local text editor instance
-        /// </summary>
-        private void ApplyLocalSettings()
-        {
-            IEditorOptions options = view.Options;
-            
-            if (settings.ContainsKey("tab_width"))
-            {
-                try
-                {
-                    int value = Convert.ToInt32(settings["tab_width"]);
-                    options.SetOptionValue<int>(DefaultOptions.TabSizeOptionId, value);
-                }
-                catch { }
-            }
-
-            if (settings.ContainsKey("indent_size"))
-            {
-                try
-                {
-                    int value = Convert.ToInt32(settings["indent_size"]);
-                    options.SetOptionValue<int>(DefaultOptions.IndentSizeOptionId, value);
-                }
-                catch { }
-            }
-
-            if (settings.ContainsKey("indent_style"))
-            {
-                string value = settings["indent_style"];
-                if (value == "tab")
-                    options.SetOptionValue<bool>(DefaultOptions.ConvertTabsToSpacesOptionId, false);
-                else if (value == "space")
-                    options.SetOptionValue<bool>(DefaultOptions.ConvertTabsToSpacesOptionId, true);
-            }
-
-            if (settings.ContainsKey("end_of_line"))
-            {
-                string value = settings["end_of_line"];
-                if (value == "lf")
-                {
-                    options.SetOptionValue<string>(DefaultOptions.NewLineCharacterOptionId, "\n");
-                    options.SetOptionValue<bool>(DefaultOptions.ReplicateNewLineCharacterOptionId, false);
-                }
-                else if (value == "cr")
-                {
-                    options.SetOptionValue<string>(DefaultOptions.NewLineCharacterOptionId, "\r");
-                    options.SetOptionValue<bool>(DefaultOptions.ReplicateNewLineCharacterOptionId, false);
-                }
-                else if (value == "crlf")
-                {
-                    options.SetOptionValue<string>(DefaultOptions.NewLineCharacterOptionId, "\r\n");
-                    options.SetOptionValue<bool>(DefaultOptions.ReplicateNewLineCharacterOptionId, false);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Applies settings to the global Visual Studio application. Some
-        /// source-code formatters, such as curly-brace auto-indenter, ignore
-        /// the local text editor settings. This causes horrible bugs when
-        /// the local text-editor settings disagree with the formatter's
-        /// settings. To fix this, just apply the same settings at the global
-        /// application level as well.
-        /// </summary>
-        private void ApplyGlobalSettings()
-        {
-            EnvDTE.Properties props;
-            try
-            {
-                string type = view.TextDataModel.ContentType.TypeName;
-                props = dte.get_Properties("TextEditor", type);
-            }
-            catch
-            {
-                // If the above code didn't work, this particular content type
-                // didn't need its settings changed anyhow
-                return;
-            }
-
-            if (settings.ContainsKey("tab_width"))
-            {
-                try
-                {
-                    int value = Convert.ToInt32(settings["tab_width"]);
-                    props.Item("TabSize").Value = value;
-                }
-                catch { }
-            }
-
-            if (settings.ContainsKey("indent_size"))
-            {
-                try
-                {
-                    int value = Convert.ToInt32(settings["indent_size"]);
-                    props.Item("IndentSize").Value = value;
-                }
-                catch { }
-            }
-
-            if (settings.ContainsKey("indent_style"))
-            {
-                string value = settings["indent_style"];
-                if (value == "tab")
-                    props.Item("InsertTabs").Value = true;
-                else if (value == "space")
-                    props.Item("InsertTabs").Value = false;
-            }
-        }
-
-        /// <summary>
-        /// Adds an error message to the Visual Studio tasks pane
-        /// </summary>
-        void ShowError(string path, string text)
-        {
-            message = new ErrorTask();
-            message.ErrorCategory = TaskErrorCategory.Error;
-            message.Category = TaskCategory.Comments;
-            message.Document = path;
-            message.Line = 0;
-            message.Column = 0;
-            message.Text = text;
-
-            messageList.Tasks.Add(message);
-            messageList.Show();
-        }
-
-        /// <summary>
-        /// Removes the file's messages, if any
-        /// </summary>
-        void ClearMessage()
-        {
-            if (message != null)
-                messageList.Tasks.Remove(message);
-            message = null;
+            _loader.Dispose();
+            _globalSettings.Dispose();
+            _doc.FileActionOccurred -= FileActionOccurred;
+            _view.Closed -= Closed;
         }
     }
 }

--- a/Plugin/Plugin.csproj
+++ b/Plugin/Plugin.csproj
@@ -39,9 +39,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Helpers\ResultsExtensions.cs" />
+    <Compile Include="Settings\GlobalSettings.cs" />
     <Compile Include="PluginFactory.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Settings\Loader.cs" />
+    <Compile Include="Settings\LocalSettings.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\LICENSE">
@@ -63,8 +67,10 @@
     <Reference Include="Microsoft.VisualStudio.Text.Logic" />
     <Reference Include="Microsoft.VisualStudio.Text.UI" />
     <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf" />
+    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wrapper\Wrapper.vcxproj">
@@ -79,7 +85,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\VSSDK\Microsoft.VsSDK.targets" Condition="false" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Plugin/Settings/GlobalSettings.cs
+++ b/Plugin/Settings/GlobalSettings.cs
@@ -1,0 +1,112 @@
+﻿using EnvDTE;
+using Microsoft.VisualStudio.Text.Editor;
+using System;
+using System.Collections.Generic;
+
+namespace EditorConfig.VisualStudio.Settings
+{
+    using Helpers;
+
+    internal class GlobalSettings : IDisposable
+    {
+        private readonly IWpfTextView _view;
+        private readonly DTE _app;
+        private readonly Dictionary<string, object> _savedGlobalProps = new Dictionary<string, object>();
+        private readonly string[] _globalPropKeys = new[] { "TabSize", "IndentSize", "InsertTabs" };
+        private readonly Results _settings;
+        private readonly Properties _editorProps;
+
+        internal GlobalSettings(IWpfTextView view, DTE app, Results settings)
+        {
+            _view = view;
+            _app = app;
+            _settings = settings;
+
+            try
+            {
+                var type = _view.TextDataModel.ContentType.TypeName;
+                _editorProps = _app.Properties["TextEditor", type];
+            }
+            catch
+            {
+                // If the above code didn't work, this particular content type
+                // didn't need its settings changed anyhow
+            }
+
+            view.GotAggregateFocus += GotAggregateFocus;
+            view.LostAggregateFocus += LostAggregateFocus;
+        }
+
+        /// <summary>
+        /// Updates the global settings when the local editor receives focus
+        /// </summary>
+        private void GotAggregateFocus(object sender, EventArgs e)
+        {
+            if (_settings == null) return;
+            Save();
+            Apply();
+        }
+
+        private void LostAggregateFocus(object sender, EventArgs eventArgs)
+        {
+            if (_settings == null) return;
+            Restore();
+        }
+
+        /// <summary>
+        /// Applies settings to the global Visual Studio application. Some
+        /// source-code formatters, such as curly-brace auto-indenter, ignore
+        /// the local text editor settings. This causes horrible bugs when
+        /// the local text-editor settings disagree with the formatter's
+        /// settings. To fix this, just apply the same settings at the global
+        /// application level as well.
+        /// </summary>
+        internal void Apply()
+        {
+            if (_editorProps == null) return;
+
+            _settings.IfHasKeyTrySetting("tab_width", i => _editorProps.Item("TabSize").Value = i);
+
+            _settings.IfHasKeyTrySetting("indent_size", i => _editorProps.Item("IndentSize").Value = i);
+
+            if (!_settings.ContainsKey("indent_style")) return;
+            switch (_settings["indent_style"])
+            {
+                case "tab":
+                    _editorProps.Item("InsertTabs").Value = true;
+                    break;
+                case "space":
+                    _editorProps.Item("InsertTabs").Value = false;
+                    break;
+            }
+        }
+
+        internal void Save()
+        {
+            if (_editorProps == null) return;
+
+            _savedGlobalProps.Clear();
+            foreach (var key in _globalPropKeys)
+                _savedGlobalProps.Add(key, _editorProps.Item(key).Value);
+        }
+
+        /// <summary>
+        /// Restores the global Visual Studio settings back to the way they were
+        /// when SaveGlobalSettings() was called.
+        /// </summary>
+        internal void Restore()
+        {
+            if (_editorProps == null) return;
+
+            foreach (var key in _savedGlobalProps.Keys)
+                _editorProps.Item(key).Value = _savedGlobalProps[key];
+        }
+
+        public void Dispose()
+        {
+            _view.GotAggregateFocus -= GotAggregateFocus;
+            _view.LostAggregateFocus -= LostAggregateFocus;
+            Restore();
+        }
+    }
+}

--- a/Plugin/Settings/Loader.cs
+++ b/Plugin/Settings/Loader.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using System;
+
+namespace EditorConfig.VisualStudio.Settings
+{
+    internal class Loader : IDisposable
+    {
+        internal Results Settings { get; private set; }
+        private readonly IWpfTextView _view;
+        private LocalSettings _localSettings;
+        private readonly ErrorListProvider _messageList;
+        private ErrorTask _message;
+
+        internal Loader(IWpfTextView view, ITextDocument document, ErrorListProvider messageList)
+        {
+            _view = view;
+            _messageList = messageList;
+            _message = null;
+
+            LoadSettings(document.FilePath);
+        }
+
+        /// <summary>
+        /// Loads the settings for the given file path
+        /// </summary>
+        internal void LoadSettings(string path)
+        {
+            ClearMessage();
+            Settings = null;
+
+            // Prevent parsing of internet-located documents,
+            // or documents that do not have proper paths.
+            if (path.StartsWith("http:", StringComparison.OrdinalIgnoreCase)
+                || path.Equals("Temp.txt"))
+                return;
+
+            try
+            {
+                Settings = Core.Parse(path);
+                if (_localSettings == null)
+                    _localSettings = new LocalSettings(_view, Settings);
+                _localSettings.Apply();
+            }
+            catch (ParseException e)
+            {
+                ShowError(path, "EditorConfig syntax error in file \"" + e.File + "\", line " + e.Line);
+            }
+            catch (CoreException e)
+            {
+                ShowError(path, "EditorConfig core error: " + e.Message);
+            }
+        }
+
+        /// <summary>
+        /// Adds an error message to the Visual Studio tasks pane
+        /// </summary>
+        private void ShowError(string path, string text)
+        {
+            _message = new ErrorTask
+            {
+                ErrorCategory = TaskErrorCategory.Error,
+                Category = TaskCategory.Comments,
+                Document = path,
+                Line = 0,
+                Column = 0,
+                Text = text
+            };
+
+            _messageList.Tasks.Add(_message);
+            _messageList.Show();
+        }
+
+        /// <summary>
+        /// Removes the file's messages, if any
+        /// </summary>
+        private void ClearMessage()
+        {
+            if (_message != null)
+                _messageList.Tasks.Remove(_message);
+            _message = null;
+        }
+
+        public void Dispose()
+        {
+            ClearMessage();
+        }
+    }
+}

--- a/Plugin/Settings/LocalSettings.cs
+++ b/Plugin/Settings/LocalSettings.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.VisualStudio.Text.Editor;
+using System.Text.RegularExpressions;
+
+namespace EditorConfig.VisualStudio.Settings
+{
+    using Helpers;
+
+    internal class LocalSettings
+    {
+        private readonly IWpfTextView _view;
+        private readonly Results _settings;
+        private readonly Regex _cr = new Regex("^cr", RegexOptions.Compiled);
+        private readonly Regex _lf = new Regex("lf$", RegexOptions.Compiled);
+
+        internal LocalSettings(IWpfTextView view, Results settings)
+        {
+            _view = view;
+            _settings = settings;
+        }
+
+        /// <summary>
+        /// Applies settings to the local text editor instance
+        /// </summary>
+        internal void Apply()
+        {
+            var options = _view.Options;
+
+            _settings.IfHasKeyTrySetting("tab_width", i => options.SetOptionValue(DefaultOptions.TabSizeOptionId, i));
+
+            _settings.IfHasKeyTrySetting("indent_size", i => options.SetOptionValue(DefaultOptions.IndentSizeOptionId, i));
+
+            if (_settings.ContainsKey("indent_style"))
+            {
+                switch (_settings["indent_style"])
+                {
+                    case "tab":
+                        options.SetOptionValue(DefaultOptions.ConvertTabsToSpacesOptionId, false);
+                        break;
+                    case "space":
+                        options.SetOptionValue(DefaultOptions.ConvertTabsToSpacesOptionId, true);
+                        break;
+                }
+            }
+
+            if (!_settings.ContainsKey("end_of_line")) return;
+
+            var newline = _lf.Replace(_cr.Replace(_settings["end_of_line"], "\r"), "\n");
+            options.SetOptionValue(DefaultOptions.NewLineCharacterOptionId, newline);
+            options.SetOptionValue(DefaultOptions.ReplicateNewLineCharacterOptionId, false);
+        }
+    }
+}

--- a/Plugin/source.extension.vsixmanifest
+++ b/Plugin/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
   <Identifier Id="EditorConfig..5cd8e6a2-be43-4fcc-a345-40f6cc1e9c9f">
     <Name>EditorConfig</Name>
     <Author>EditorConfig Team</Author>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <Description xml:space="preserve">Loads editor options such as indentation sizes from standard, cross-platform .editorconfig files.</Description>
     <Locale>1033</Locale>
     <MoreInfoUrl>http://editorconfig.org/</MoreInfoUrl>

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 0.3.1
+
+* Restores global settings when document loses focus
+
+## 0.3.0
+
+* Built against Core 0.11.0
+
 ## 0.2.6
 
 * Visual Studio 2012 support


### PR DESCRIPTION
Pulled some things out into different files for loose coupling. Lots of refactoring.

Also, fixed an issue I was experiencing where EditorConfig was overwriting global settings w/o restoring them.
