### PR TITLE
TrimTrailingWhitespace fails for "whitespace-only" lines

### DIFF
--- a/Plugin/SettingsViewApplier.cs
+++ b/Plugin/SettingsViewApplier.cs
@@ -54,6 +54,7 @@ namespace EditorConfig.VisualStudio
 
                     int length = line.Length;
 
+                    // How long is a whitespace-only line?
                     if (length == 0)
                     {
                         continue;
@@ -72,6 +73,7 @@ namespace EditorConfig.VisualStudio
                         continue;
                     }
 
+                    // What is the start position of a whitespace-only line?
                     edit.Delete(line.Start.Position + pos + 1, length - 1 - pos);
                 }
 


### PR DESCRIPTION
If a file contains _whitespace-only_ lines, the whitespace is **_not**_ removed when **trim_trailing_spaces** is set to true.

After looking at the code it's not immediately obvious why that would be the case. It all look reasonable. I've added a comment to 2 lines where the issue may lie.

I'm hoping this is a simple fix. However, just let me know if you want me to look into it.

Thanks

PS This would probably be better as an Issue than a pull request?
