### PR TITLE
Fix a bug when file contains a line that only contains whitespace

### DIFF
--- a/Plugin/SettingsViewApplier.cs
+++ b/Plugin/SettingsViewApplier.cs
@@ -62,7 +62,7 @@ namespace EditorConfig.VisualStudio
                     string content = line.GetText();
 
                     int pos = length - 1;
-                    while (IsWhiteSpace(content[pos]))
+                    while ( pos >= 0 && IsWhiteSpace(content[pos]))
                     {
                         pos --;
                     }


### PR DESCRIPTION
Editorconfig visual studio extension will will fail to process a file that contains a line that only contains white spaces.
![image](https://cloud.githubusercontent.com/assets/4053944/4184569/a1190474-374b-11e4-9abb-b16c215be4d4.png)

When processing a line only contains whitespaces, pos will become -1 when reached beginning of the line. Then content[-1] will cause a out of index exception.
