### PR TITLE
Added support for fixing EOL's when applying settings if the current fil...

### DIFF
--- a/Plugin/SettingsViewApplier.cs
+++ b/Plugin/SettingsViewApplier.cs
@@ -20,6 +20,11 @@ namespace EditorConfig.VisualStudio
             {
                 TrimTrailingWhitespace(view);
             }
+
+            if (settings.EndOfLine != null)
+            {
+                EnsureEndOfLine(view, settings.EndOfLine);
+            }
         }
 
         private static bool IsWhiteSpace(Char c)
@@ -98,6 +103,34 @@ namespace EditorConfig.VisualStudio
             using (var edit = snapshot.TextBuffer.CreateEdit())
             {
                 edit.Insert(snapshot.Length, view.Options.GetNewLineCharacter());
+                edit.Apply();
+            }
+        }
+
+        private static void EnsureEndOfLine(IWpfTextView view, string endOfLine)
+        {
+            ITextSnapshot snapshot = view.TextSnapshot;
+            var lineCount = snapshot.LineCount;
+
+            if (lineCount == 0)
+            {
+                return;
+            }
+
+            using (var edit = snapshot.TextBuffer.CreateEdit())
+            {
+                for (int i = 0; i < lineCount; i++)
+                {
+                    ITextSnapshotLine line = snapshot.GetLineFromLineNumber(i);
+
+                    var existingLineBreakText = line.GetLineBreakText();
+                    if (existingLineBreakText != endOfLine && !string.IsNullOrEmpty(existingLineBreakText))
+                    {
+                        edit.Delete(line.End.Position, existingLineBreakText.Length);
+                        edit.Insert(line.End.Position, endOfLine);
+                    }
+                }
+
                 edit.Apply();
             }
         }

--- a/Wrapper/Wrapper.vcxproj
+++ b/Wrapper/Wrapper.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{85F4C576-ECA4-44D7-98D0-FE065632C51E}</ProjectGuid>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>EditorConfig</RootNamespace>
   </PropertyGroup>
@@ -22,14 +22,14 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
...e has an EOL setting chosen for it.

This is important when using ReSharper, which only supports CRLF(*). If you have a file type set to LF, and then do any edits or refactors where ReSharper is involved, the file will get saved out with mixed EOL's. This commit will work around the ReSharper limitation.

(*) Is an issue for all ReSharpers up to at least 8.2.1; see https://youtrack.jetbrains.com/issue/RSRP-274916