### PR TITLE
Fixed high-profile spelling mistake

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # EditorConfig Visual Studio Plugin
 
-This plugin causes Visual Studio to load it's indentation options from a standard `.editorconfig` settings file. See the [project web site](http://editorconfig.org) for more information.
+This plugin causes Visual Studio to load its indentation options from a standard `.editorconfig` settings file. See the [project web site](http://editorconfig.org) for more information.
 
 ## Installing
 


### PR DESCRIPTION
Not that anyone was confused, but it was right in the first sentence of the project description.