### PR TITLE
Fix a StackOverflowException when trying to rename a type with v0.6

### DIFF
--- a/EditorConfig.VisualStudio/EditorConfig.VisualStudio.csproj
+++ b/EditorConfig.VisualStudio/EditorConfig.VisualStudio.csproj
@@ -24,6 +24,9 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <!-- This is added to prevent forced migrations in Visual Studio -->
     <MinimumVisualStudioVersion Condition="'$(VisualStudioVersion)' != ''">$(VisualStudioVersion)</MinimumVisualStudioVersion>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/EditorConfig.VisualStudio/EditorConfig.VisualStudio.csproj
+++ b/EditorConfig.VisualStudio/EditorConfig.VisualStudio.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Completion\EditorConfigCompletionSource.cs" />
     <Compile Include="ContentType\EditorConfigContentTypeDefinition.cs" />
     <Compile Include="EditorConfigTextViewCreationListener.cs" />
+    <Compile Include="Helpers\ActiveDocumentRestorer.cs" />
     <Compile Include="Helpers\EditPointExtensions.cs" />
     <Compile Include="Helpers\OutputWindowHelper.cs" />
     <Compile Include="Helpers\SettingsExtensions.cs" />

--- a/EditorConfig.VisualStudio/EditorConfigPackage.cs
+++ b/EditorConfig.VisualStudio/EditorConfigPackage.cs
@@ -103,6 +103,30 @@ namespace EditorConfig.VisualStudio
             get { return IDEVersion.Major < 11; }
         }
 
+        /// <summary>
+        /// Gets the currently active document, otherwise null.
+        /// </summary>
+        public Document ActiveDocument
+        {
+            get
+            {
+                try
+                {
+                    return IDE.ActiveDocument;
+                }
+                catch (Exception)
+                {
+                    // If a project property page is active, accessing the ActiveDocument causes an exception.
+                    return null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a flag indicating if EditorConfig is running inside an AutoSave context.
+        /// </summary>
+        public static bool IsAutoSaveContext { get; set; }
+
         #endregion Public Integration Properties
 
         #region Private Event Listener Properties

--- a/EditorConfig.VisualStudio/Helpers/ActiveDocumentRestorer.cs
+++ b/EditorConfig.VisualStudio/Helpers/ActiveDocumentRestorer.cs
@@ -1,0 +1,89 @@
+﻿#region CodeMaid is Copyright 2007-2016 Steve Cadwallader.
+
+// CodeMaid is free software: you can redistribute it and/or modify it under the terms of the GNU
+// Lesser General Public License version 3 as published by the Free Software Foundation.
+//
+// CodeMaid is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details <http://www.gnu.org/licenses/>.
+
+#endregion CodeMaid is Copyright 2007-2016 Steve Cadwallader.
+
+using System;
+using EnvDTE;
+
+namespace EditorConfig.VisualStudio.Helpers
+{
+    /// <summary>
+    /// A class that handles tracking a document and switching back to it, typically in a using
+    /// statement context.
+    /// </summary>
+    internal class ActiveDocumentRestorer : IDisposable
+    {
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActiveDocumentRestorer" /> class.
+        /// </summary>
+        /// <param name="package">The hosting package.</param>
+        internal ActiveDocumentRestorer(EditorConfigPackage package)
+        {
+            Package = package;
+
+            StartTracking();
+        }
+
+        #endregion Constructors
+
+        #region Internal Methods
+
+        /// <summary>
+        /// Starts tracking the active document.
+        /// </summary>
+        internal void StartTracking()
+        {
+            // Cache the active document.
+            TrackedDocument = Package.ActiveDocument;
+        }
+
+        /// <summary>
+        /// Restores the tracked document if not already active.
+        /// </summary>
+        internal void RestoreTrackedDocument()
+        {
+            if (TrackedDocument != null && Package.ActiveDocument != TrackedDocument)
+            {
+                TrackedDocument.Activate();
+            }
+        }
+
+        #endregion Internal Methods
+
+        #region IDisposable Members
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting
+        /// unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            RestoreTrackedDocument();
+        }
+
+        #endregion IDisposable Members
+
+        #region Private Properties
+
+        /// <summary>
+        /// Gets or sets the hosting package.
+        /// </summary>
+        private EditorConfigPackage Package { get; set; }
+
+        /// <summary>
+        /// Gets or sets the active document.
+        /// </summary>
+        private Document TrackedDocument { get; set; }
+
+        #endregion Private Properties
+    }
+}

--- a/EditorConfig.VisualStudio/Helpers/UndoTransactionHelper.cs
+++ b/EditorConfig.VisualStudio/Helpers/UndoTransactionHelper.cs
@@ -33,22 +33,13 @@ namespace EditorConfig.VisualStudio.Helpers
         #region Methods
 
         /// <summary>
-        /// Runs the specified try action within a try block.
-        /// </summary>
-        /// <param name="tryAction">The action to be performed within a try block.</param>
-        public void Run(Action tryAction)
-        {
-            Run(() => true, tryAction, ex => { });
-        }
-
-        /// <summary>
         /// Runs the specified try action within a try block, and conditionally the catch action within a catch block.
         /// </summary>
         /// <param name="tryAction">The action to be performed within a try block.</param>
         /// <param name="catchAction">The action to be performed wihin a catch block.</param>
-        public void Run(Action tryAction, Action<Exception> catchAction)
+        public void Run(Action tryAction, Action<Exception> catchAction = null)
         {
-            Run(() => true, tryAction, catchAction);
+            Run(() => !EditorConfigPackage.IsAutoSaveContext, tryAction, catchAction);
         }
 
         /// <summary>
@@ -74,7 +65,7 @@ namespace EditorConfig.VisualStudio.Helpers
             }
             catch (Exception ex)
             {
-                catchAction(ex);
+                if (catchAction != null) catchAction(ex);
 
                 if (!shouldCloseUndoContext) return;
                 _ide.UndoContext.SetAborted();

--- a/EditorConfig.VisualStudio/Integration/Commands/CleanupActiveCodeCommand.cs
+++ b/EditorConfig.VisualStudio/Integration/Commands/CleanupActiveCodeCommand.cs
@@ -1,5 +1,6 @@
 ﻿using EnvDTE;
 using System.ComponentModel.Design;
+using EditorConfig.VisualStudio.Helpers;
 
 namespace EditorConfig.VisualStudio.Integration.Commands
 {
@@ -63,7 +64,19 @@ namespace EditorConfig.VisualStudio.Integration.Commands
         /// <param name="document">The document about to be saved.</param>
         internal void OnBeforeDocumentSave(Document document)
         {
-            CodeCleanupManager.Cleanup(document);
+            try
+            {
+                EditorConfigPackage.IsAutoSaveContext = true;
+
+                using (new ActiveDocumentRestorer(Package))
+                {
+                    CodeCleanupManager.Cleanup(document);
+                }
+            }
+            finally
+            {
+                EditorConfigPackage.IsAutoSaveContext = false;
+            }
         }
 
         #endregion Internal Methods


### PR DESCRIPTION
This PR fixes a StackOverflow exception that occurs when trying to rename a type. It is causes by the Undo transaction entering an infinite loop during saving, which happens as a result of a rename.