### PR TITLE
Fix NullReferenceException error for pathless files

### DIFF
--- a/src/EditorConfig.VisualStudio/Helpers/SettingsExtensions.cs
+++ b/src/EditorConfig.VisualStudio/Helpers/SettingsExtensions.cs
@@ -11,6 +11,7 @@ namespace EditorConfig.VisualStudio.Helpers
         public static bool TryLoad(string path, out FileConfiguration fileConfiguration)
         {
             fileConfiguration = null;
+            if (string.IsNullOrEmpty(path)) return false;
             var parser = new EditorConfigParser();
             var configurations = parser.Parse(path);
             if (!configurations.Any()) return false;


### PR DESCRIPTION
## Overview

When the new VS Text Editor is opened with some special output (e.g. Stack Trace Explorer in ReSharper), it has no path,
so the argument `path` in `SettingsExtensions.TryLoad` is null, and `NullReferenceException` is thrown in `parser.Parse(string)`.
So null-check must be needed.
## Repro
1. Install both EditorConfig extension and ReSharper (an example) in Visual Studio instance.
2. Open Stack Trace Explorer in ReSharper. Parsed stack trace are shown in [Stack Trace Explorer] pane.
3. But suddenly [Error List] pane is shown with EditorConfig extension's `NullReferenceException`.
